### PR TITLE
Fix NPE in DataFluentAppender

### DIFF
--- a/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
@@ -116,7 +116,9 @@ public class DataFluentAppender extends UnsynchronizedAppenderBase<ILoggingEvent
         try {
             super.stop();
         } finally {
-            appender.close();
+            if (appender != null) {
+                appender.close();
+            }
         }
     }
 


### PR DESCRIPTION
If you use Spring Boot framework  with Fluentd logback appender then you get NPE because Spring Boot tries to stop DataFluentAppender before it will be initialized.