### PR TITLE
add more fields to FluencyLogbackAppender

### DIFF
--- a/src/test/resources/logback-appenders.xml
+++ b/src/test/resources/logback-appenders.xml
@@ -90,6 +90,16 @@
       </remoteServer>
     </remoteServers>
 
+    <!-- [Optional] Additional fields(Pairs of key: value) -->
+    <additionalField>
+      <key>foo</key>
+      <value>bar</value>
+    </additionalField>
+    <additionalField>
+      <key>foo2</key>
+      <value>bar2</value>
+    </additionalField>
+
     <!-- [Optional] Configurations to customize Fluency's behavior: https://github.com/komamitsu/fluency#usage  -->
     <ackResponseMode>true</ackResponseMode>
     <fileBackupDir>/tmp</fileBackupDir>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -7,6 +7,7 @@
   <logger name="ch.qos.logback.more.appenders.LogbackAppenderTest" level="TRACE">
     <appender-ref ref="FLUENT" />
     <appender-ref ref="FLUENT_TEXT" />
+    <appender-ref ref="FLUENCY" />
     <appender-ref ref="DYNAMODB" />
   </logger>
 


### PR DESCRIPTION
This p-r adds some fields (message, logger, level etc ..), to have compatible with other appenders, due to #17.

One point to discuss: 
Is it better to rename `msg` to something like `log` or not? Because new field `message` is added.