### PR TITLE
Fix issue 21 https://github.com/sndyuk/logback-more-appenders/issues/21

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ is additional appenders for [Logback](http://logback.qos.ch/).
 
 ### Latest changes
 
+##### Version 1.4.3
+
+* Added new parameter to FLUENCY appender: 
+  useEventTime, set to true to use EventTime instead of standard timestamp and gain millisecond precision
+  use fluentd option time_format to change time resolution in messages
+  
+* Update FLUENCY dependency version to 1.6.0
+
 ##### Version 1.4.2
 
 * Added new fluentds fields to FLUENCY appender.  

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <fluentd.logger.version>0.3.2</fluentd.logger.version>
-    <fluency.version>1.0.0</fluency.version>
+    <fluency.version>1.6.0</fluency.version>
     <logback.version>1.1.7</logback.version>
     <aws.version>1.10.77</aws.version>
     <jdk.version>1.6</jdk.version>

--- a/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import org.komamitsu.fluency.EventTime;
 import org.komamitsu.fluency.Fluency;
 
 import java.io.IOException;
@@ -80,7 +81,12 @@ public class FluencyLogbackAppender extends UnsynchronizedAppenderBase<ILoggingE
             data.put(entry.getKey(), entry.getValue());
         }
         try {
-            fluency.emit(tag == null ? "" : tag, data);
+            if (this.isUseEventTime()){
+                EventTime eventTime = EventTime.fromEpochMilli(System.currentTimeMillis());
+                fluency.emit(tag == null ? "" : tag, eventTime, data);
+            }else {
+                fluency.emit(tag == null ? "" : tag, data);
+            }
         } catch (IOException e) {
             // pass
         }
@@ -116,6 +122,7 @@ public class FluencyLogbackAppender extends UnsynchronizedAppenderBase<ILoggingE
     private Integer waitUntilFlusherTerminated;
     private Integer flushIntervalMillis;
     private Integer senderMaxRetryCount;
+    private boolean useEventTime; // Flag to enable/disable usage of eventtime
 
     public RemoteServers getRemoteServers() {
         return remoteServers;
@@ -235,6 +242,18 @@ public class FluencyLogbackAppender extends UnsynchronizedAppenderBase<ILoggingE
     public void setSenderMaxRetryCount(Integer senderMaxRetryCount) {
         this.senderMaxRetryCount = senderMaxRetryCount;
     }
+
+    /**
+     * get the value for EventTime usage
+     * @return true if EventTime is used, false otherwise
+     */
+    public boolean isUseEventTime(){ return this.useEventTime; }
+
+    /**
+     * Set the value for EventTime usage
+     * @param useEventTime the new value
+     */
+    public void setUseEventTime(boolean useEventTime){ this.useEventTime = useEventTime; }
 
     protected Fluency.Config configureFluency() {
         Fluency.Config config = new Fluency.Config().setAckResponseMode(ackResponseMode);

--- a/src/test/resources/logback-appenders.xml
+++ b/src/test/resources/logback-appenders.xml
@@ -79,7 +79,7 @@
     <port>24224</port>
 
     <!-- [Optional] Multiple name/addresses and port numbers which Flentd placed -->
-    <remoteServers>
+   <remoteServers>
       <remoteServer>
         <host>primary</host>
         <port>24224</port>
@@ -110,6 +110,8 @@
     <waitUntilFlusherTerminated>40</waitUntilFlusherTerminated>
     <flushIntervalMillis>200</flushIntervalMillis>
     <senderMaxRetryCount>12</senderMaxRetryCount>
+    <!-- [Optional] Enable/Disable use of EventTime to get sub second resolution of log event date-time -->
+    <useEventTime>true</useEventTime>
 
     <layout class="ch.qos.logback.classic.PatternLayout">
       <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg]]></pattern>


### PR DESCRIPTION
I add a parameter to fluency appender to enable/disable the use of EventTime (see fluency doc)
in conjunction with fluentd time_format option i finally get millisecond resolution in log events.