### PR TITLE
Removing ILoggingEvent constraint

### DIFF
--- a/src/test/resources/logback-appenders.xml
+++ b/src/test/resources/logback-appenders.xml
@@ -114,9 +114,9 @@
     <!-- [Optional] Enable/Disable use of EventTime to get sub second resolution of log event date-time -->
     <useEventTime>true</useEventTime>
 
-    <layout class="ch.qos.logback.classic.PatternLayout">
+    <encoder>
       <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg]]></pattern>
-    </layout>
+    </encoder>
   </appender>
 
 


### PR DESCRIPTION
Removing ILoggingEvent constraint in order to allow other events like IAccessEvent to be reported by Fluency.

Changes: 
- Replacing ILoggingEvent generic with E
- Using Encoder instead of direct Layout in order to allow logging conversions out of the box (see [OutputStreamAppender](https://logback.qos.ch/xref/ch/qos/logback/core/OutputStreamAppender.html)). This change is retrocompatible. 