### PR TITLE
Migrate Fluency to 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ is additional appenders for [Logback](http://logback.qos.ch/) and provide better
 
 ### Latest changes
 
+##### Version 1.5.5
+
+* Update FLUENCY dependency version to 2.2.1
+
 ##### Version 1.5.4
 
 * Added JSON Encoder.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sndyuk</groupId>
   <artifactId>logback-more-appenders</artifactId>
-  <version>1.5.4</version>
+  <version>1.5.5</version>
   <name>logback-more-appenders</name>
   <description>logback appenders.</description>
   <url>https://github.com/sndyuk/logback-more-appenders</url>
@@ -17,7 +17,7 @@
 
   <properties>
     <fluentd.logger.version>0.3.3</fluentd.logger.version>
-    <fluency.version>1.8.1</fluency.version>
+    <fluency.version>2.2.1</fluency.version>
     <logback.version>1.2.3</logback.version>
     <jackson.version>2.9.8</jackson.version>
     <aws.version>1.11.504</aws.version>
@@ -123,10 +123,18 @@
 
     <dependency>
       <groupId>org.komamitsu</groupId>
-      <artifactId>fluency</artifactId>
+      <artifactId>fluency-core</artifactId>
       <version>${fluency.version}</version>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.komamitsu</groupId>
+      <artifactId>fluency-fluentd</artifactId>
+      <version>${fluency.version}</version>
+      <optional>true</optional>
+    </dependency>
+
 
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
@@ -27,6 +27,8 @@ import org.komamitsu.fluency.Fluency;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.encoder.Encoder;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import org.komamitsu.fluency.FluencyBuilder;
+import org.komamitsu.fluency.fluentd.FluencyBuilderForFluentd;
 
 public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
 
@@ -62,7 +64,8 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         super.start();
 
         try {
-            this.fluency = Fluency.defaultFluency(configureServers(), configureFluency());
+            FluencyBuilderForFluentd builder = configureFluency();
+            this.fluency = builder.build(configureServers());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -236,19 +239,21 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
      */
     public void setUseEventTime(boolean useEventTime) { this.useEventTime = useEventTime; }
 
-    protected Fluency.Config configureFluency() {
-        Fluency.Config config = new Fluency.Config().setAckResponseMode(ackResponseMode);
-        if (fileBackupDir != null) { config.setFileBackupDir(fileBackupDir); }
-        if (bufferChunkInitialSize != null) { config.setBufferChunkInitialSize(bufferChunkInitialSize); }
-        if (bufferChunkRetentionSize != null) { config.setBufferChunkRetentionSize(bufferChunkRetentionSize); }
-        if (maxBufferSize != null) { config.setMaxBufferSize(maxBufferSize); }
-        if (waitUntilBufferFlushed != null) { config.setWaitUntilBufferFlushed(waitUntilBufferFlushed); }
-        if (waitUntilFlusherTerminated != null) { config.setWaitUntilFlusherTerminated(waitUntilFlusherTerminated); }
-        if (flushIntervalMillis != null) { config.setFlushIntervalMillis(flushIntervalMillis); }
-        if (senderMaxRetryCount != null) { config.setSenderMaxRetryCount(senderMaxRetryCount); }
-        config.setSslEnabled(sslEnabled);
+    protected FluencyBuilderForFluentd configureFluency() {
+        FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
 
-        return config;
+        builder.setAckResponseMode(ackResponseMode);
+        if (fileBackupDir != null) { builder.setFileBackupDir(fileBackupDir); }
+        if (bufferChunkInitialSize != null) { builder.setBufferChunkInitialSize(bufferChunkInitialSize); }
+        if (bufferChunkRetentionSize != null) { builder.setBufferChunkRetentionSize(bufferChunkRetentionSize); }
+        if (maxBufferSize != null) { builder.setMaxBufferSize(maxBufferSize); }
+        if (waitUntilBufferFlushed != null) { builder.setWaitUntilBufferFlushed(waitUntilBufferFlushed); }
+        if (waitUntilFlusherTerminated != null) { builder.setWaitUntilFlusherTerminated(waitUntilFlusherTerminated); }
+        if (flushIntervalMillis != null) { builder.setFlushIntervalMillis(flushIntervalMillis); }
+        if (senderMaxRetryCount != null) { builder.setSenderMaxRetryCount(senderMaxRetryCount); }
+        builder.setSslEnabled(sslEnabled);
+
+        return builder;
     }
 
     protected List<InetSocketAddress> configureServers() {


### PR DESCRIPTION
This is really a minimal set of changes required to add the support. Tested it manually and seems to work just fine with my remote fluentd instance.