### PR TITLE
Fix issue 23 with NPE after closing the appender

### DIFF
--- a/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
@@ -62,7 +62,7 @@ public class DataFluentAppender<E> extends FluentdAppenderBase<E> {
             super.stop();
         } finally {
             try {
-                fluentLogger.close();
+                FluentLogger.closeAll();
             } catch (Exception e) {
                 // pass
             }


### PR DESCRIPTION
This PR fixes the issue #23 with NPE that happens after the appender is closed.
It is also related to https://github.com/fluent/fluent-logger-java/issues/64 and https://github.com/fluent/fluent-logger-java/issues/75

The issue is that `DataFluentAppender` directly calls `fluentLogger.close()` method. The close() method flushes the sender and then sets it to null:

```java
sender.flush();
sender.close();
sender = null;
```
By doing so, the appender stays in the `FluentLoggerFactory.loggers` map pool, while having a null `sender`.

When a new logger is asked in `FluentLoggerFactory.getLogger()`, the method first searches in the  `FluentLoggerFactory.loggers` map and finds the closed one, so this closed appender is returned. 

But because the `FluentLogger.sender` has been set to null, it throws an NPE.

The solution is very simple and straightforward: call `FluentLogger.closeAll()` instead : it will still call the `fluentLogger.close()` method **AND** remove it from the  `FluentLoggerFactory.loggers` map pool. 

When a new logger will be asked, a new one will be created and returned, and no more NPE :) 