### PR TITLE
Add `connectionTimeoutMilli` and `readTimeoutMilli` to Fluency support.

### DIFF
--- a/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
@@ -109,6 +109,8 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
     private Integer bufferChunkInitialSize;
     private Integer bufferChunkRetentionSize;
     private Long maxBufferSize;
+    private Integer connectionTimeoutMilli;
+    private Integer readTimeoutMilli;
     private Integer waitUntilBufferFlushed;
     private Integer waitUntilFlusherTerminated;
     private Integer flushIntervalMillis;
@@ -192,6 +194,22 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         this.maxBufferSize = maxBufferSize;
     }
 
+    public Integer getConnectionTimeoutMilli() {
+        return connectionTimeoutMilli;
+    }
+
+    public void setConnectionTimeoutMilli(Integer connectionTimeoutMilli) {
+        this.connectionTimeoutMilli = connectionTimeoutMilli;
+    }
+
+    public Integer getReadTimeoutMilli() {
+        return readTimeoutMilli;
+    }
+
+    public void setReadTimeoutMilli(Integer readTimeoutMilli) {
+        this.readTimeoutMilli = readTimeoutMilli;
+    }
+
     public Integer getWaitUntilBufferFlushed() {
         return waitUntilBufferFlushed;
     }
@@ -246,6 +264,8 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         if (bufferChunkInitialSize != null) { builder.setBufferChunkInitialSize(bufferChunkInitialSize); }
         if (bufferChunkRetentionSize != null) { builder.setBufferChunkRetentionSize(bufferChunkRetentionSize); }
         if (maxBufferSize != null) { builder.setMaxBufferSize(maxBufferSize); }
+        if (connectionTimeoutMilli != null) { builder.setConnectionTimeoutMilli(connectionTimeoutMilli); }
+        if (readTimeoutMilli != null) { builder.setReadTimeoutMilli(readTimeoutMilli); }
         if (waitUntilBufferFlushed != null) { builder.setWaitUntilBufferFlushed(waitUntilBufferFlushed); }
         if (waitUntilFlusherTerminated != null) { builder.setWaitUntilFlusherTerminated(waitUntilFlusherTerminated); }
         if (flushIntervalMillis != null) { builder.setFlushIntervalMillis(flushIntervalMillis); }

--- a/src/test/resources/logback-appenders-fluentd.xml
+++ b/src/test/resources/logback-appenders-fluentd.xml
@@ -83,6 +83,8 @@
     <bufferChunkInitialSize>2097152</bufferChunkInitialSize>
     <bufferChunkRetentionSize>16777216</bufferChunkRetentionSize>
     <maxBufferSize>268435456</maxBufferSize>
+    <connectionTimeoutMilli>5000</connectionTimeoutMilli>
+    <readTimeoutMilli>5000</readTimeoutMilli>
     <waitUntilBufferFlushed>30</waitUntilBufferFlushed>
     <waitUntilFlusherTerminated>40</waitUntilFlusherTerminated>
     <flushIntervalMillis>200</flushIntervalMillis>


### PR DESCRIPTION
Thank you for providing such a wonderful fluency logback Appender.

The default `readTimeoutMilli` of  Fluency is `5000`, and seems not enough for my environment to complete most requests. This MR add support for both `connectionTimeoutMilli` and `readTimeoutMilli` property for Fluency.