### PR TITLE
Call toString on map instead of mapStr to avoid NullPointerException

### DIFF
--- a/src/main/java/ch/qos/logback/more/appenders/marker/MapMarker.java
+++ b/src/main/java/ch/qos/logback/more/appenders/marker/MapMarker.java
@@ -60,7 +60,7 @@ public class MapMarker extends LeafMarker {
     @Override
     public String toString() {
         if (mapStr == null) {
-            mapStr = mapStr.toString();
+            mapStr = map.toString();
         }
         return getName() + '{' + mapStr + '}';
     }


### PR DESCRIPTION
This PR is to resolve a NullPointerException which occurs when calling a method on a null object.
The toString should be called on the map instead of the null mapStr.