### PR TITLE
Use single host fluency build method when single host configured in logback xml config

### DIFF
--- a/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
@@ -64,7 +64,11 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
 
         try {
             FluencyBuilderForFluentd builder = configureFluency();
-            this.fluency = builder.build(configureServers());
+            if (remoteHost != null && port > 0 && (remoteServers == null || remoteServers.getRemoteServers().size() == 0)) {
+                this.fluency = builder.build(remoteHost, port);
+            } else {
+                this.fluency = builder.build(configureServers());
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
When calling the fluency build method which accepts a List of servers fluency will use MultiSender and enable hearbeater. Right now logback-more-appenders always uses this build method regardless of how many servers are configured. This commit changes that so given the xml config "\<remoteHost\>someremotehost\</remoteHost\>" logback-more-appenders will instead call the single host fluency build method. This is turn will create a single sender without heartbeat enabled.