### PR TITLE
Upgrade Fluency version from 2.2.1 to 2.4.1

### DIFF
--- a/pom-JAVA9MODULE_SLF4J17.xml
+++ b/pom-JAVA9MODULE_SLF4J17.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <fluentd.logger.version>0.3.4</fluentd.logger.version>
-    <fluency.version>2.2.1</fluency.version>
+    <fluency.version>2.4.1</fluency.version>
     <logback.version>1.2.3</logback.version>
     <slf4j.version>1.7.26</slf4j.version>
     <jackson.version>2.9.8</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <fluentd.logger.version>0.3.4</fluentd.logger.version>
-    <fluency.version>2.2.1</fluency.version>
+    <fluency.version>2.4.1</fluency.version>
     <logback.version>1.2.3</logback.version>
     <jackson.version>2.9.8</jackson.version>
     <aws.version>1.11.642</aws.version>

--- a/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
@@ -130,7 +130,7 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
     private Integer readTimeoutMilli;
     private Integer waitUntilBufferFlushed;
     private Integer waitUntilFlusherTerminated;
-    private Integer flushIntervalMillis;
+    private Integer flushAttemptIntervalMillis;
     private Integer senderMaxRetryCount;
     private boolean useEventTime; // Flag to enable/disable usage of eventtime
     private boolean sslEnabled;
@@ -243,12 +243,12 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         this.waitUntilFlusherTerminated = waitUntilFlusherTerminated;
     }
 
-    public Integer getFlushIntervalMillis() {
-        return flushIntervalMillis;
+    public Integer getFlushAttemptIntervalMillis() {
+        return flushAttemptIntervalMillis;
     }
 
-    public void setFlushIntervalMillis(Integer flushIntervalMillis) {
-        this.flushIntervalMillis = flushIntervalMillis;
+    public void setFlushAttemptIntervalMillis(Integer flushAttemptIntervalMillis) {
+        this.flushAttemptIntervalMillis = flushAttemptIntervalMillis;
     }
 
     public Integer getSenderMaxRetryCount() {
@@ -285,7 +285,7 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         if (readTimeoutMilli != null) { builder.setReadTimeoutMilli(readTimeoutMilli); }
         if (waitUntilBufferFlushed != null) { builder.setWaitUntilBufferFlushed(waitUntilBufferFlushed); }
         if (waitUntilFlusherTerminated != null) { builder.setWaitUntilFlusherTerminated(waitUntilFlusherTerminated); }
-        if (flushIntervalMillis != null) { builder.setFlushIntervalMillis(flushIntervalMillis); }
+        if (flushAttemptIntervalMillis != null) { builder.setFlushAttemptIntervalMillis(flushAttemptIntervalMillis); }
         if (senderMaxRetryCount != null) { builder.setSenderMaxRetryCount(senderMaxRetryCount); }
         builder.setSslEnabled(sslEnabled);
 

--- a/src/test/resources/logback-appenders-fluentd.xml
+++ b/src/test/resources/logback-appenders-fluentd.xml
@@ -87,7 +87,7 @@
     <readTimeoutMilli>5000</readTimeoutMilli>
     <waitUntilBufferFlushed>30</waitUntilBufferFlushed>
     <waitUntilFlusherTerminated>40</waitUntilFlusherTerminated>
-    <flushIntervalMillis>200</flushIntervalMillis>
+    <flushAttemptIntervalMillis>200</flushAttemptIntervalMillis>
     <senderMaxRetryCount>12</senderMaxRetryCount>
     <!-- [Optional] Enable/Disable use of EventTime to get sub second resolution of log event date-time -->
     <useEventTime>true</useEventTime>


### PR DESCRIPTION
Fluency 2.4.0 or earlier has a bug that happens with the combination of SSL mode and JVM heap mode. I think logback-more-appenders would be better to use 2.4.1.

Latest Fluency has deprecated `org.komamitsu.fluency.FluencyBuilder.setFlushIntervalMillis()`, so this PR also uses an alternative method instead.