### PR TITLE
Expose FluentdAppenderBase as public

### DIFF
--- a/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
+public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
     private static final String DATA_MESSAGE = "message";
     private static final String DATA_LOGGER = "logger";
     private static final String DATA_THREAD = "thread";


### PR DESCRIPTION
It would be great to expose it because there some cases which need custom implementations