### PR TITLE
custom map marker prefix option

### DIFF
--- a/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
@@ -13,52 +13,19 @@
  */
 package ch.qos.logback.more.appenders;
 
-import ch.qos.logback.core.Layout;
-import ch.qos.logback.core.encoder.Encoder;
-import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
-import org.fluentd.logger.FluentLogger;
-
-import java.util.HashMap;
 import java.util.Map;
 
-import static ch.qos.logback.core.CoreConstants.CODES_URL;
+import org.fluentd.logger.FluentLogger;
 
 public class DataFluentAppender<E> extends FluentdAppenderBase<E> {
     private FluentLogger fluentLogger;
 
-    @Deprecated
-    public void setLayout(Layout<E> layout) {
-        addWarn("This appender no longer admits a layout as a sub-component, set an encoder instead.");
-        addWarn("To ensure compatibility, wrapping your layout in LayoutWrappingEncoder.");
-        addWarn("See also " + CODES_URL + "#layoutInsteadOfEncoder for details");
-        LayoutWrappingEncoder<E> lwe = new LayoutWrappingEncoder<E>();
-        lwe.setLayout(layout);
-        lwe.setContext(context);
-        this.encoder = lwe;
-    }
-
-    public void setEncoder(Encoder<E> encoder) {
-        this.encoder = encoder;
-    }
-
-    public void setMessageFieldKeyName(String messageFieldKeyName) { this.messageFieldKeyName = messageFieldKeyName; }
-
-    public void addAdditionalField(Field field) {
-        if (additionalFields == null) {
-            additionalFields = new HashMap<String, String>();
-        }
-        additionalFields.put(field.getKey(), field.getValue());
-    }
-
-    public boolean isFlattenMapMarker() { return flattenMapMarker; }
-    public void setFlattenMapMarker(boolean flattenMapMarker) { this.flattenMapMarker = flattenMapMarker; }
-
     @Override
     public void start() {
-        fluentLogger = FluentLogger.getLogger(label != null ? tag : null, remoteHost, port, getTimeout(), getBufferCapacity());
+        fluentLogger = FluentLogger.getLogger(label != null ? tag : null, remoteHost, port, getTimeout(),
+                getBufferCapacity());
         super.start();
     }
-
 
     @Override
     public void stop() {
@@ -84,21 +51,10 @@ public class DataFluentAppender<E> extends FluentdAppenderBase<E> {
         }
     }
 
-    private String tag;
-    private String label;
-    private String remoteHost;
-    private int port;
-    private boolean useEventTime;
     private Integer timeout;
     private Integer bufferCapacity;
 
-    public String getTag() {
-        return tag;
-    }
-
-    public void setTag(String tag) {
-        this.tag = tag;
-    }
+    private String label;
 
     public String getLabel() {
         return label;
@@ -106,30 +62,6 @@ public class DataFluentAppender<E> extends FluentdAppenderBase<E> {
 
     public void setLabel(String label) {
         this.label = label;
-    }
-
-    public String getRemoteHost() {
-        return remoteHost;
-    }
-
-    public void setRemoteHost(String remoteHost) {
-        this.remoteHost = remoteHost;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-    public void setPort(int port) {
-        this.port = port;
-    }
-
-    public boolean isUseEventTime() {
-        return this.useEventTime;
-    }
-
-    public void setUseEventTime(boolean useEventTime) {
-        this.useEventTime = useEventTime;
     }
 
     public void setTimeout(Integer timeout) {

--- a/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
@@ -22,8 +22,8 @@ public class DataFluentAppender<E> extends FluentdAppenderBase<E> {
 
     @Override
     public void start() {
-        fluentLogger = FluentLogger.getLogger(label != null ? tag : null, remoteHost, port, getTimeout(),
-                getBufferCapacity());
+        fluentLogger = FluentLogger.getLogger(getLabel() != null ? getTag() : null, getRemoteHost(), getPort(),
+                getTimeout(), getBufferCapacity());
         super.start();
     }
 
@@ -44,16 +44,15 @@ public class DataFluentAppender<E> extends FluentdAppenderBase<E> {
     protected void append(E event) {
         Map<String, Object> data = createData(event);
 
-        if (useEventTime) {
-            fluentLogger.log(label == null ? tag : label, data, System.currentTimeMillis() / 1000);
+        if (isUseEventTime()) {
+            fluentLogger.log(getLabel() == null ? getTag() : getLabel(), data, System.currentTimeMillis() / 1000);
         } else {
-            fluentLogger.log(label == null ? tag : label, data);
+            fluentLogger.log(getLabel() == null ? getTag() : getLabel(), data);
         }
     }
 
     private Integer timeout;
     private Integer bufferCapacity;
-
     private String label;
 
     public String getLabel() {

--- a/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
@@ -36,9 +36,9 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
     public void start() {
         try {
             FluencyBuilderForFluentd builder = configureFluency();
-            if (remoteHost != null && port > 0
+            if (getRemoteHost() != null && getPort() > 0
                     && (remoteServers == null || remoteServers.getRemoteServers().size() == 0)) {
-                this.fluency = builder.build(remoteHost, port);
+                this.fluency = builder.build(getRemoteHost(), getPort());
             } else {
                 this.fluency = builder.build(configureServers());
             }
@@ -52,8 +52,8 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
     protected void append(E event) {
         Map<String, Object> data = createData(event);
         try {
-            String tag = this.tag == null ? "" : this.tag;
-            if (this.isUseEventTime()) {
+            String tag = getTag() == null ? "" : getTag();
+            if (isUseEventTime()) {
                 EventTime eventTime;
                 if (event instanceof ILoggingEvent) {
                     long timeStampInMs = ((ILoggingEvent) event).getTimeStamp();
@@ -262,8 +262,8 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
 
     protected List<InetSocketAddress> configureServers() {
         List<InetSocketAddress> dest = new ArrayList<InetSocketAddress>();
-        if (remoteHost != null && port > 0) {
-            dest.add(new InetSocketAddress(remoteHost, port));
+        if (getRemoteHost() != null && getPort() > 0) {
+            dest.add(new InetSocketAddress(getRemoteHost(), getPort()));
         }
         if (remoteServers != null) {
             for (RemoteServer server : remoteServers.getRemoteServers()) {

--- a/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluencyLogbackAppender.java
@@ -15,60 +15,29 @@
  */
 package ch.qos.logback.more.appenders;
 
-import ch.qos.logback.access.spi.IAccessEvent;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Layout;
-import ch.qos.logback.core.encoder.Encoder;
-import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.komamitsu.fluency.EventTime;
 import org.komamitsu.fluency.Fluency;
 import org.komamitsu.fluency.fluentd.FluencyBuilderForFluentd;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static ch.qos.logback.core.CoreConstants.CODES_URL;
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
 
     private Fluency fluency;
 
-    @Deprecated
-    public void setLayout(Layout<E> layout) {
-        addWarn("This appender no longer admits a layout as a sub-component, set an encoder instead.");
-        addWarn("To ensure compatibility, wrapping your layout in LayoutWrappingEncoder.");
-        addWarn("See also " + CODES_URL + "#layoutInsteadOfEncoder for details");
-        LayoutWrappingEncoder<E> lwe = new LayoutWrappingEncoder<E>();
-        lwe.setLayout(layout);
-        lwe.setContext(context);
-        this.encoder = lwe;
-    }
-
-    public void setEncoder(Encoder<E> encoder) {
-        this.encoder = encoder;
-    }
-
-    public void setMessageFieldKeyName(String messageFieldKeyName) { this.messageFieldKeyName = messageFieldKeyName; }
-
-    public void addAdditionalField(Field field) {
-        if (additionalFields == null) {
-            additionalFields = new HashMap<String, String>();
-        }
-        additionalFields.put(field.getKey(), field.getValue());
-    }
-
-    public boolean isFlattenMapMarker() { return flattenMapMarker; }
-    public void setFlattenMapMarker(boolean flattenMapMarker) { this.flattenMapMarker = flattenMapMarker; }
-
     @Override
     public void start() {
         try {
             FluencyBuilderForFluentd builder = configureFluency();
-            if (remoteHost != null && port > 0 && (remoteServers == null || remoteServers.getRemoteServers().size() == 0)) {
+            if (remoteHost != null && port > 0
+                    && (remoteServers == null || remoteServers.getRemoteServers().size() == 0)) {
                 this.fluency = builder.build(remoteHost, port);
             } else {
                 this.fluency = builder.build(configureServers());
@@ -112,7 +81,8 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         } finally {
             try {
                 fluency.flush();
-                long maxWaitMillis = Math.min((waitUntilBufferFlushed != null ? waitUntilBufferFlushed : 1) + (waitUntilFlusherTerminated != null ? waitUntilFlusherTerminated : 1), 5) * 1000;
+                long maxWaitMillis = Math.min((waitUntilBufferFlushed != null ? waitUntilBufferFlushed : 1)
+                        + (waitUntilFlusherTerminated != null ? waitUntilFlusherTerminated : 1), 5) * 1000;
                 Thread.sleep(maxWaitMillis);
                 fluency.close();
             } catch (Exception e) {
@@ -121,9 +91,6 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         }
     }
 
-    private String tag;
-    private String remoteHost;
-    private int port;
     private RemoteServers remoteServers;
     private boolean ackResponseMode;
     private String fileBackupDir;
@@ -137,7 +104,6 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
     private Integer waitUntilFlusherTerminated;
     private Integer flushAttemptIntervalMillis;
     private Integer senderMaxRetryCount;
-    private boolean useEventTime; // Flag to enable/disable usage of eventtime
     private boolean sslEnabled;
 
     public RemoteServers getRemoteServers() {
@@ -148,33 +114,13 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         this.remoteServers = remoteServers;
     }
 
-    public String getTag() {
-        return tag;
+    public boolean isSslEnabled() {
+        return sslEnabled;
     }
 
-    public void setTag(String tag) {
-        this.tag = tag;
+    public void setSslEnabled(boolean useSsl) {
+        this.sslEnabled = useSsl;
     }
-
-    public String getRemoteHost() {
-        return remoteHost;
-    }
-
-    public void setRemoteHost(String remoteHost) {
-        this.remoteHost = remoteHost;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-    public void setPort(int port) {
-        this.port = port;
-    }
-
-    public boolean isSslEnabled() { return sslEnabled; }
-
-    public void setSslEnabled(boolean useSsl) { this.sslEnabled = useSsl; }
 
     public boolean isAckResponseMode() {
         return ackResponseMode;
@@ -272,35 +218,43 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         this.senderMaxRetryCount = senderMaxRetryCount;
     }
 
-    /**
-     * get the value for EventTime usage
-     *
-     * @return true if EventTime is used, false otherwise
-     */
-    public boolean isUseEventTime() { return this.useEventTime; }
-
-    /**
-     * Set the value for EventTime usage
-     *
-     * @param useEventTime the new value
-     */
-    public void setUseEventTime(boolean useEventTime) { this.useEventTime = useEventTime; }
-
     protected FluencyBuilderForFluentd configureFluency() {
         FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
 
         builder.setAckResponseMode(ackResponseMode);
-        if (fileBackupDir != null) { builder.setFileBackupDir(fileBackupDir); }
-        if (bufferChunkInitialSize != null) { builder.setBufferChunkInitialSize(bufferChunkInitialSize); }
-        if (bufferChunkRetentionSize != null) { builder.setBufferChunkRetentionSize(bufferChunkRetentionSize); }
-        if (bufferChunkRetentionTimeMillis != null) { builder.setBufferChunkRetentionTimeMillis(bufferChunkRetentionTimeMillis); }
-        if (maxBufferSize != null) { builder.setMaxBufferSize(maxBufferSize); }
-        if (connectionTimeoutMilli != null) { builder.setConnectionTimeoutMilli(connectionTimeoutMilli); }
-        if (readTimeoutMilli != null) { builder.setReadTimeoutMilli(readTimeoutMilli); }
-        if (waitUntilBufferFlushed != null) { builder.setWaitUntilBufferFlushed(waitUntilBufferFlushed); }
-        if (waitUntilFlusherTerminated != null) { builder.setWaitUntilFlusherTerminated(waitUntilFlusherTerminated); }
-        if (flushAttemptIntervalMillis != null) { builder.setFlushAttemptIntervalMillis(flushAttemptIntervalMillis); }
-        if (senderMaxRetryCount != null) { builder.setSenderMaxRetryCount(senderMaxRetryCount); }
+        if (fileBackupDir != null) {
+            builder.setFileBackupDir(fileBackupDir);
+        }
+        if (bufferChunkInitialSize != null) {
+            builder.setBufferChunkInitialSize(bufferChunkInitialSize);
+        }
+        if (bufferChunkRetentionSize != null) {
+            builder.setBufferChunkRetentionSize(bufferChunkRetentionSize);
+        }
+        if (bufferChunkRetentionTimeMillis != null) {
+            builder.setBufferChunkRetentionTimeMillis(bufferChunkRetentionTimeMillis);
+        }
+        if (maxBufferSize != null) {
+            builder.setMaxBufferSize(maxBufferSize);
+        }
+        if (connectionTimeoutMilli != null) {
+            builder.setConnectionTimeoutMilli(connectionTimeoutMilli);
+        }
+        if (readTimeoutMilli != null) {
+            builder.setReadTimeoutMilli(readTimeoutMilli);
+        }
+        if (waitUntilBufferFlushed != null) {
+            builder.setWaitUntilBufferFlushed(waitUntilBufferFlushed);
+        }
+        if (waitUntilFlusherTerminated != null) {
+            builder.setWaitUntilFlusherTerminated(waitUntilFlusherTerminated);
+        }
+        if (flushAttemptIntervalMillis != null) {
+            builder.setFlushAttemptIntervalMillis(flushAttemptIntervalMillis);
+        }
+        if (senderMaxRetryCount != null) {
+            builder.setSenderMaxRetryCount(senderMaxRetryCount);
+        }
         builder.setSslEnabled(sslEnabled);
 
         return builder;
@@ -358,4 +312,3 @@ public class FluencyLogbackAppender<E> extends FluentdAppenderBase<E> {
         }
     }
 }
-

--- a/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
@@ -42,7 +42,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
     private Encoder<E> encoder;
     protected Map<String, String> additionalFields;
     private boolean flattenMapMarker;
-    private String mapMarkerPrefix = DATA_MARKER;
+    private String markerPrefix = DATA_MARKER;
     private String messageFieldKeyName = DATA_MESSAGE;
 
     protected Map<String, Object> createData(E event) {
@@ -59,7 +59,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
                 if (marker instanceof MapMarker) {
                     extractMapMarker((MapMarker) marker, data);
                 } else {
-                    data.put(mapMarkerName(), marker.toString());
+                    data.put(markerName(), marker.toString());
                     if (marker.hasReferences()) {
                         for (Iterator<Marker> iter = marker.iterator(); iter.hasNext();) {
                             Marker nestedMarker = iter.next();
@@ -108,12 +108,12 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
     }
 
     /**
-     * Get map marker name if not a map
+     * Get marker name (if not a map)
      * 
-     * @return maprker name
+     * @return marker name
      */
-    protected String mapMarkerName() {
-        return (emptyString(mapMarkerPrefix)) ? DATA_MARKER : mapMarkerPrefix;
+    protected String markerName() {
+        return (emptyString(markerPrefix)) ? DATA_MARKER : markerPrefix;
     }
 
     /**
@@ -124,12 +124,12 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
      */
     protected String mapMarkerName(MapMarker mapMarker) {
         if ((mapMarker == null) || (emptyString(mapMarker.getName()))) {
-            return mapMarkerName();
+            return markerName();
         }
-        if (emptyString(mapMarkerPrefix)) {
+        if (emptyString(markerPrefix)) {
             return mapMarker.getName();
         }
-        return mapMarkerPrefix + "." + mapMarker.getName();
+        return markerPrefix + "." + mapMarker.getName();
     }
 
     public static class Field {
@@ -244,17 +244,17 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
         this.flattenMapMarker = flattenMapMarker;
     }
 
-    public String getMapMarkerPrefix() {
-        return mapMarkerPrefix;
+    public String getMarkerPrefix() {
+        return markerPrefix;
     }
 
     /**
-     * Set Map Marker Prefix
+     * Set Marker Prefix
      * 
-     * @param mapMarkerPrefix - string representing map marker prefix. If null, use
-     *                        default. If blank, no prefix is used.
+     * @param markerPrefix - string representing marker prefix. If null, use
+     *                     default. If blank, no prefix is used.
      */
-    public void setMapMarkerPrefix(String mapMarkerPrefix) {
-        this.mapMarkerPrefix = (mapMarkerPrefix != null) ? mapMarkerPrefix : DATA_MARKER;
+    public void setMarkerPrefix(String markerPrefix) {
+        this.markerPrefix = (markerPrefix != null) ? markerPrefix : DATA_MARKER;
     }
 }

--- a/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
@@ -13,17 +13,22 @@
  */
 package ch.qos.logback.more.appenders;
 
-import ch.qos.logback.classic.pattern.CallerDataConverter;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.ThrowableProxyUtil;
-import ch.qos.logback.core.AppenderBase;
-import ch.qos.logback.core.encoder.Encoder;
-import ch.qos.logback.more.appenders.marker.MapMarker;
-import org.slf4j.Marker;
+import static ch.qos.logback.core.CoreConstants.CODES_URL;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+
+import org.slf4j.Marker;
+
+import ch.qos.logback.classic.pattern.CallerDataConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.Layout;
+import ch.qos.logback.core.encoder.Encoder;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.more.appenders.marker.MapMarker;
 
 public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
     private static final String DATA_MESSAGE = "message";
@@ -37,6 +42,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
     protected Encoder<E> encoder;
     protected Map<String, String> additionalFields;
     protected boolean flattenMapMarker;
+    protected String mapMarkerPrefix = DATA_MARKER;
     protected String messageFieldKeyName = DATA_MESSAGE;
 
     protected Map<String, Object> createData(E event) {
@@ -53,7 +59,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
                 if (marker instanceof MapMarker) {
                     extractMapMarker((MapMarker) marker, data);
                 } else {
-                    data.put(DATA_MARKER, marker.toString());
+                    data.put(mapMarkerName(), marker.toString());
                     if (marker.hasReferences()) {
                         for (Iterator<Marker> iter = marker.iterator(); iter.hasNext();) {
                             Marker nestedMarker = iter.next();
@@ -69,8 +75,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
                 data.put(DATA_CALLER, new CallerDataConverter().convert(loggingEvent));
             }
             if (loggingEvent.getThrowableProxy() != null) {
-                data.put(DATA_THROWABLE,
-                        ThrowableProxyUtil.asString(loggingEvent.getThrowableProxy()));
+                data.put(DATA_THROWABLE, ThrowableProxyUtil.asString(loggingEvent.getThrowableProxy()));
             }
             for (Map.Entry<String, String> entry : loggingEvent.getMDCPropertyMap().entrySet()) {
                 data.put(entry.getKey(), entry.getValue());
@@ -88,9 +93,43 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
     private void extractMapMarker(MapMarker mapMarker, Map<String, Object> data) {
         if (flattenMapMarker) {
             data.putAll(mapMarker.getMap());
-        } else {
-            data.put(DATA_MARKER + "." + mapMarker.getName(), mapMarker.getMap());
+        } else
+            data.put(mapMarkerName(mapMarker), mapMarker.getMap());
+    }
+
+    /**
+     * Check if string is null or empty
+     * 
+     * @param string to check
+     * @return true if null or empty
+     */
+    private boolean emptyString(String string) {
+        return ((string == null) || (string.isEmpty()));
+    }
+
+    /**
+     * Get map marker name if not a map
+     * 
+     * @return maprker name
+     */
+    private String mapMarkerName() {
+        return (emptyString(mapMarkerPrefix)) ? DATA_MARKER : mapMarkerPrefix;
+    }
+
+    /**
+     * Get map marker name if map is provided
+     * 
+     * @param mapMarker
+     * @return
+     */
+    private String mapMarkerName(MapMarker mapMarker) {
+        if ((mapMarker == null) || (emptyString(mapMarker.getName()))) {
+            return mapMarkerName();
         }
+        if (emptyString(mapMarkerPrefix)) {
+            return mapMarker.getName();
+        }
+        return mapMarkerPrefix + "." + mapMarker.getName();
     }
 
     public static class Field {
@@ -112,5 +151,104 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
         public void setValue(String value) {
             this.value = value;
         }
+    }
+
+    /* formerly duplicated code */
+
+    protected String tag;
+    protected String remoteHost;
+    protected int port;
+    protected boolean useEventTime; // Flag to enable/disable usage of eventtime
+
+    public void addAdditionalField(Field field) {
+        if (additionalFields == null) {
+            additionalFields = new HashMap<String, String>();
+        }
+        additionalFields.put(field.getKey(), field.getValue());
+    }
+
+    @Deprecated
+    public void setLayout(Layout<E> layout) {
+        addWarn("This appender no longer admits a layout as a sub-component, set an encoder instead.");
+        addWarn("To ensure compatibility, wrapping your layout in LayoutWrappingEncoder.");
+        addWarn("See also " + CODES_URL + "#layoutInsteadOfEncoder for details");
+        LayoutWrappingEncoder<E> lwe = new LayoutWrappingEncoder<E>();
+        lwe.setLayout(layout);
+        lwe.setContext(context);
+        this.setEncoder(lwe);
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    public String getRemoteHost() {
+        return remoteHost;
+    }
+
+    public void setRemoteHost(String remoteHost) {
+        this.remoteHost = remoteHost;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    /**
+     * get the value for EventTime usage
+     *
+     * @return true if EventTime is used, false otherwise
+     */
+    public boolean isUseEventTime() {
+        return this.useEventTime;
+    }
+
+    /**
+     * Set the value for EventTime usage
+     *
+     * @param useEventTime the new value
+     */
+    public void setUseEventTime(boolean useEventTime) {
+        this.useEventTime = useEventTime;
+    }
+
+    public Encoder<E> getEncoder() {
+        return encoder;
+    }
+
+    public void setEncoder(Encoder<E> encoder) {
+        this.encoder = encoder;
+    }
+
+    public String getMessageFieldKeyName() {
+        return messageFieldKeyName;
+    }
+
+    public void setMessageFieldKeyName(String messageFieldKeyName) {
+        this.messageFieldKeyName = messageFieldKeyName;
+    }
+
+    public boolean isFlattenMapMarker() {
+        return flattenMapMarker;
+    }
+
+    public void setFlattenMapMarker(boolean flattenMapMarker) {
+        this.flattenMapMarker = flattenMapMarker;
+    }
+
+    public String getMapMarkerPrefix() {
+        return mapMarkerPrefix;
+    }
+
+    public void setMapMarkerPrefix(String mapMarkerPrefix) {
+        this.mapMarkerPrefix = (mapMarkerPrefix != null) ? mapMarkerPrefix : DATA_MARKER;
     }
 }

--- a/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
@@ -39,11 +39,11 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
     private static final String DATA_CALLER = "caller";
     private static final String DATA_THROWABLE = "throwable";
 
-    protected Encoder<E> encoder;
+    private Encoder<E> encoder;
     protected Map<String, String> additionalFields;
-    protected boolean flattenMapMarker;
-    protected String mapMarkerPrefix = DATA_MARKER;
-    protected String messageFieldKeyName = DATA_MESSAGE;
+    private boolean flattenMapMarker;
+    private String mapMarkerPrefix = DATA_MARKER;
+    private String messageFieldKeyName = DATA_MESSAGE;
 
     protected Map<String, Object> createData(E event) {
         Map<String, Object> data = new HashMap<String, Object>();
@@ -90,7 +90,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
         return data;
     }
 
-    private void extractMapMarker(MapMarker mapMarker, Map<String, Object> data) {
+    protected void extractMapMarker(MapMarker mapMarker, Map<String, Object> data) {
         if (flattenMapMarker) {
             data.putAll(mapMarker.getMap());
         } else
@@ -103,7 +103,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
      * @param string to check
      * @return true if null or empty
      */
-    private boolean emptyString(String string) {
+    public static boolean emptyString(String string) {
         return ((string == null) || (string.isEmpty()));
     }
 
@@ -112,7 +112,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
      * 
      * @return maprker name
      */
-    private String mapMarkerName() {
+    protected String mapMarkerName() {
         return (emptyString(mapMarkerPrefix)) ? DATA_MARKER : mapMarkerPrefix;
     }
 
@@ -122,7 +122,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
      * @param mapMarker
      * @return
      */
-    private String mapMarkerName(MapMarker mapMarker) {
+    protected String mapMarkerName(MapMarker mapMarker) {
         if ((mapMarker == null) || (emptyString(mapMarker.getName()))) {
             return mapMarkerName();
         }
@@ -155,10 +155,10 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
 
     /* formerly duplicated code */
 
-    protected String tag;
-    protected String remoteHost;
-    protected int port;
-    protected boolean useEventTime; // Flag to enable/disable usage of eventtime
+    private String tag;
+    private String remoteHost;
+    private int port;
+    private boolean useEventTime; // Flag to enable/disable usage of eventtime
 
     public void addAdditionalField(Field field) {
         if (additionalFields == null) {
@@ -248,6 +248,12 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
         return mapMarkerPrefix;
     }
 
+    /**
+     * Set Map Marker Prefix
+     * 
+     * @param mapMarkerPrefix - string representing map marker prefix. If null, use
+     *                        default. If blank, no prefix is used.
+     */
     public void setMapMarkerPrefix(String mapMarkerPrefix) {
         this.mapMarkerPrefix = (mapMarkerPrefix != null) ? mapMarkerPrefix : DATA_MARKER;
     }

--- a/src/test/java/ch/qos/logback/more/appenders/FluentdAppenderBaseTest.java
+++ b/src/test/java/ch/qos/logback/more/appenders/FluentdAppenderBaseTest.java
@@ -219,13 +219,13 @@ public class FluentdAppenderBaseTest {
     @Test
     public void mapMarkerNameTest() {
         TestAppender<Object> appender = new TestAppender<>();
-        assertEquals("marker", appender.mapMarkerName());
-        appender.setMapMarkerPrefix("custom");
-        assertEquals("custom", appender.mapMarkerName());
-        appender.setMapMarkerPrefix("");
-        assertEquals("marker", appender.mapMarkerName());
-        appender.setMapMarkerPrefix(null);
-        assertEquals("marker", appender.mapMarkerName());
+        assertEquals("marker", appender.markerName());
+        appender.setMarkerPrefix("custom");
+        assertEquals("custom", appender.markerName());
+        appender.setMarkerPrefix("");
+        assertEquals("marker", appender.markerName());
+        appender.setMarkerPrefix(null);
+        assertEquals("marker", appender.markerName());
     }
 
     @Test
@@ -236,13 +236,13 @@ public class FluentdAppenderBaseTest {
         // default map marker prefix
         assertEquals("marker.MAP_MARKER", appender.mapMarkerName(mapMarker));
 
-        appender.setMapMarkerPrefix("custom");
+        appender.setMarkerPrefix("custom");
         assertEquals("custom.MAP_MARKER", appender.mapMarkerName(mapMarker));
 
-        appender.setMapMarkerPrefix("");
+        appender.setMarkerPrefix("");
         assertEquals("MAP_MARKER", appender.mapMarkerName(mapMarker));
 
-        appender.setMapMarkerPrefix(null);
+        appender.setMarkerPrefix(null);
         assertEquals("marker.MAP_MARKER", appender.mapMarkerName(mapMarker));
     }
 
@@ -312,7 +312,7 @@ public class FluentdAppenderBaseTest {
     @Test
     public void createDataILoggingEventWithMapMarkerNoPrefix() {
         TestAppender<Object> appender = new TestAppender<>();
-        appender.setMapMarkerPrefix("");
+        appender.setMarkerPrefix("");
         MapMarker mapMarker = makeMapMarker("MAP_MARKER");
 
         TestEvent testEvent = new TestEvent("Test Message");

--- a/src/test/java/ch/qos/logback/more/appenders/FluentdAppenderBaseTest.java
+++ b/src/test/java/ch/qos/logback/more/appenders/FluentdAppenderBaseTest.java
@@ -1,0 +1,330 @@
+/**
+ * Copyright (c) 2020 sndyuk <sanada@sndyuk.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.more.appenders;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.slf4j.Marker;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import ch.qos.logback.more.appenders.marker.MapMarker;
+
+public class FluentdAppenderBaseTest {
+
+    /**
+     * Creating a test appender to be a test proxy
+     */
+    class TestAppender<E> extends FluentdAppenderBase<E> {
+        protected List<E> appended = new ArrayList<E>();
+
+        @Override
+        protected void append(E event) {
+            appended.add(event);
+        }
+
+    }
+
+    class TestEvent implements ILoggingEvent {
+
+        Object[] argumentArray = { "arg1", "arg2" };
+        StackTraceElement[] callerData;
+        Level level = Level.INFO;
+        LoggerContextVO loggerContextVO;
+        String loggerName = "defaultLoggerName";
+        Map<String, String> mdcPropertyMap = new HashMap<>();
+        Marker marker = null;
+        Map<String, String> mdc = new HashMap<>();
+        final String message;
+        final long timeStamp;
+        final String threadName = "threadName";
+        IThrowableProxy throwableProxy;
+
+        public TestEvent(String message) {
+            this.message = message;
+            this.timeStamp = System.currentTimeMillis();
+        }
+
+        // Fluent setters for testing
+        public TestEvent setArgumentArray(Object[] argumentArray) {
+            this.argumentArray = argumentArray;
+            return this;
+        }
+
+        public TestEvent setCallerData(StackTraceElement[] callerData) {
+            this.callerData = callerData;
+            return this;
+        }
+
+        public TestEvent setLevel(Level level) {
+            this.level = level;
+            return this;
+        }
+
+        public TestEvent setLoggerContextVO(LoggerContextVO loggerContextVO) {
+            this.loggerContextVO = loggerContextVO;
+            return this;
+        }
+
+        public TestEvent setLoggerName(String loggerName) {
+            this.loggerName = loggerName;
+            return this;
+        }
+
+        public TestEvent setMdcPropertyMap(Map<String, String> mdcPropertyMap) {
+            this.mdcPropertyMap = mdcPropertyMap;
+            return this;
+        }
+
+        // Fluent setters for testing
+        public TestEvent setMarker(Marker marker) {
+            this.marker = marker;
+            return this;
+        }
+
+        public TestEvent setMdc(Map<String, String> mdc) {
+            this.mdc = mdc;
+            return this;
+        }
+
+        public TestEvent setThrowableProxy(IThrowableProxy throwableProxy) {
+            this.throwableProxy = throwableProxy;
+            return this;
+        }
+
+        @Override
+        public Object[] getArgumentArray() {
+            return argumentArray;
+        }
+
+        @Override
+        public StackTraceElement[] getCallerData() {
+            return callerData;
+        }
+
+        @Override
+        public String getFormattedMessage() {
+            return this.message;
+        }
+
+        @Override
+        public Level getLevel() {
+            return level;
+        }
+
+        @Override
+        public LoggerContextVO getLoggerContextVO() {
+            return loggerContextVO;
+        }
+
+        @Override
+        public String getLoggerName() {
+            return loggerName;
+        }
+
+        @Override
+        public Map<String, String> getMDCPropertyMap() {
+            return mdcPropertyMap;
+        }
+
+        @Override
+        public Marker getMarker() {
+            return marker;
+        }
+
+        @Override
+        public Map<String, String> getMdc() {
+            return mdc;
+        }
+
+        @Override
+        public String getMessage() {
+            return message;
+        }
+
+        @Override
+        public String getThreadName() {
+            return threadName;
+        }
+
+        @Override
+        public IThrowableProxy getThrowableProxy() {
+            return throwableProxy;
+        }
+
+        @Override
+        public long getTimeStamp() {
+            return timeStamp;
+        }
+
+        @Override
+        public boolean hasCallerData() {
+            return ((callerData != null) && (callerData.length > 0));
+        }
+
+        @Override
+        public void prepareForDeferredProcessing() {
+        }
+
+    }
+
+    private MapMarker makeMapMarker(String name) {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+
+        return new MapMarker(name, map);
+
+    }
+
+    @Test
+    public void emptyStringTestEmpty() {
+        String[] empty = { null, "" };
+        for (String testString : empty) {
+            assertTrue("Expecting '" + testString + "' to be empty", FluentdAppenderBase.emptyString(testString));
+        }
+    }
+
+    @Test
+    public void emptyStringTestNotEmpty() {
+        String[] empty = { " ", "string" };
+        for (String testString : empty) {
+            assertFalse("Expecting '" + testString + "' to be not empty", FluentdAppenderBase.emptyString(testString));
+        }
+    }
+
+    @Test
+    public void mapMarkerNameTest() {
+        TestAppender<Object> appender = new TestAppender<>();
+        assertEquals("marker", appender.mapMarkerName());
+        appender.setMapMarkerPrefix("custom");
+        assertEquals("custom", appender.mapMarkerName());
+        appender.setMapMarkerPrefix("");
+        assertEquals("marker", appender.mapMarkerName());
+        appender.setMapMarkerPrefix(null);
+        assertEquals("marker", appender.mapMarkerName());
+    }
+
+    @Test
+    public void mapMarkerNameWithMarkerMapTest() {
+        TestAppender<Object> appender = new TestAppender<>();
+        MapMarker mapMarker = makeMapMarker("MAP_MARKER");
+
+        // default map marker prefix
+        assertEquals("marker.MAP_MARKER", appender.mapMarkerName(mapMarker));
+
+        appender.setMapMarkerPrefix("custom");
+        assertEquals("custom.MAP_MARKER", appender.mapMarkerName(mapMarker));
+
+        appender.setMapMarkerPrefix("");
+        assertEquals("MAP_MARKER", appender.mapMarkerName(mapMarker));
+
+        appender.setMapMarkerPrefix(null);
+        assertEquals("marker.MAP_MARKER", appender.mapMarkerName(mapMarker));
+    }
+
+    private void assertExpectedData(Map<String, Object> expected, TestAppender<Object> appender, Object testEvent) {
+
+        assertEquals(expected, appender.createData(testEvent));
+    }
+
+    /**
+     * Test createData with non-ILoggingEvent argument
+     */
+    @Test
+    public void createDataNonILoggingEvent() {
+        TestAppender<Object> appender = new TestAppender<>();
+
+        Object testEvent = "TEST";
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("message", testEvent);
+
+        assertExpectedData(expected, appender, testEvent);
+    }
+
+    /**
+     * Test createData with ILoggingEvent argument
+     */
+    @Test
+    public void createDataILoggingEvent() {
+        TestAppender<Object> appender = new TestAppender<>();
+
+        ILoggingEvent testEvent = new TestEvent("Test Message");
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("message", testEvent.getFormattedMessage());
+        expected.put("level", testEvent.getLevel().toString());
+        expected.put("logger", testEvent.getLoggerName());
+        expected.put("thread", testEvent.getThreadName());
+
+        assertExpectedData(expected, appender, testEvent);
+    }
+
+    /**
+     * Test createData with ILoggingEvent argument with Map Marker with default
+     * prefix
+     */
+    @Test
+    public void createDataILoggingEventWithMapMarker1() {
+        TestAppender<Object> appender = new TestAppender<>();
+        MapMarker mapMarker = makeMapMarker("MAP_MARKER");
+
+        TestEvent testEvent = new TestEvent("Test Message");
+        testEvent.setMarker(mapMarker).setLevel(Level.ERROR);
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("message", testEvent.getFormattedMessage());
+        expected.put("level", testEvent.getLevel().toString());
+        expected.put("logger", testEvent.getLoggerName());
+        expected.put("thread", testEvent.getThreadName());
+        expected.put("marker.MAP_MARKER", mapMarker.getMap());
+
+        assertExpectedData(expected, appender, testEvent);
+    }
+
+    /**
+     * Test createData with ILoggingEvent argument with MapMarker without a prefix
+     */
+    @Test
+    public void createDataILoggingEventWithMapMarkerNoPrefix() {
+        TestAppender<Object> appender = new TestAppender<>();
+        appender.setMapMarkerPrefix("");
+        MapMarker mapMarker = makeMapMarker("MAP_MARKER");
+
+        TestEvent testEvent = new TestEvent("Test Message");
+        testEvent.setMarker(mapMarker).setLevel(Level.ERROR);
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("message", testEvent.getFormattedMessage());
+        expected.put("level", testEvent.getLevel().toString());
+        expected.put("logger", testEvent.getLoggerName());
+        expected.put("thread", testEvent.getThreadName());
+        expected.put("MAP_MARKER", mapMarker.getMap());
+
+        assertExpectedData(expected, appender, testEvent);
+    }
+}


### PR DESCRIPTION
Quick pass at  #51

Added "mapMarkerPrefix" parameter, which if set to blank string "" will remove the prefix altogether

This is more of a proof of concept, rather than PR. I tried to add some unit testing for new stuff, but I am not sure I fully follow the existing unit tests. So I created some of my own and in the process realized there was a ton of code replicated between two Fluentd implementations. I ended up trying to clean it up, so now there are a ton of changes - even though practically - I just moved duplicated code into the base class.

Anyway, let me know what you think...