### PR TITLE
Add maxEventCount configuration to CloudWatch appenders.

### DIFF
--- a/src/test/resources/logback-appenders-aws.xml
+++ b/src/test/resources/logback-appenders-aws.xml
@@ -33,6 +33,10 @@
     <!-- The minimum interval millis for each CloudWatch API call. -->
     <emitInterval>100</emitInterval>
 
+    <!-- [Optional] Maximum number of log events for each CloudWatch API call.
+    <maxEventCount>300</maxEventCount>
+    -->
+
     <!-- The FastJsonEncoder treats the log as JSON. -->
     <encoder class="ch.qos.logback.more.appenders.encoder.FastJsonEncoder">
       <pattern><![CDATA[{


### PR DESCRIPTION
Hello,
this pull request introduces an optional `maxEventCount` parameter to both `CloudWatchLogbackAppender` and `CloudWatchLogbackAppenderV2`. This parameter limits the number of log events sent to CloudWatch per API call.

I need this feature for my use case, where my CloudWatch log group streams data to S3 via Firehose. Since the S3 folder structure is partitioned, Firehose has an option to decompress the data from CloudWatch to split it before writing to S3. However, if more than 500 events per batch are received, Firehose fails with the following error:

> Firehose did not de-aggregate the records because the count of split records exceeded limit of 500.
> DynamicPartitioning.DeAggregationRecordCountLimitExceeded

This limitation is also documented in the [Firehose documentation](https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecordBatch.html):

> For multi record de-aggregation, you can not put more than 500 records even if the data blob
> length is less than 1000 KiB. If you include more than 500 records, the request succeeds but the
> record de-aggregation doesn't work as expected and transformation lambda is invoked with the
> complete base64 encoded data blob instead of de-aggregated base64 decoded records.
