### PR TITLE
Dependencies updates, fluentd deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Just add it to your dependency then you can use the slf4j module in your applica
 * Update AWS Java SDK v1 to 1.11.1034
 * Update AWS Java SDK v2 to 2.16.104
 * Update Maven plugins to the latest version
-* Add Enforces and versions maven plugins
+* Add enforcer and versions maven plugins
 
 ##### Version 1.8.8
 * Fix CloudWatch appenders duplicate logs: https://github.com/sndyuk/logback-more-appenders/pull/71

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ For questions or support, please use the [GitHub repository Issues](https://gith
 - [Kinesis Stream](https://aws.amazon.com/kinesis/data-streams/)
     - depends on [kinesis(v2) or aws-java-sdk-kinesis(v1)](http://aws.amazon.com/sdkforjava/).
 
-- [fluentd](http://fluentd.org/)
+- [fluentd](http://fluentd.org/) [(DEPRECATED)](https://github.com/fluent/fluent-logger-java/issues/99) use fluency instead
     - depends on [fluent-logger for Java](https://github.com/fluent/fluent-logger-java).
-     - Install fluentd before running logger.
+    - Install fluentd before running logger.
 
 - [fluency](https://github.com/komamitsu/fluency)
     - depends on [fluency](https://github.com/komamitsu/fluency).
@@ -35,7 +35,7 @@ Just add it to your dependency then you can use the slf4j module in your applica
 
 ##### Gradle
 ```
-  implementation 'com.sndyuk:logback-more-appenders:1.8.8-JAVA9MODULE_SLF4J17'
+  implementation 'com.sndyuk:logback-more-appenders:1.8.9-JAVA9MODULE_SLF4J17'
 ```
 
 ##### Maven
@@ -43,7 +43,7 @@ Just add it to your dependency then you can use the slf4j module in your applica
   <dependency>
     <groupId>ch.qos.logback</groupId>
     <artifactId>logback-classic</artifactId>
-    <version>1.8.8-JAVA9MODULE_SLF4J17</version>
+    <version>1.8.9-JAVA9MODULE_SLF4J17</version>
   </dependency>
 ```
 
@@ -54,6 +54,16 @@ Just add it to your dependency then you can use the slf4j module in your applica
 
 
 ### Latest changes
+
+##### Version 1.8.9
+* Requires Java 8
+* Update fluency to 2.7.3
+* Update logback to 1.2.13
+* Update jackson to 2.15.2
+* Update AWS Java SDK v1 to 1.11.1034
+* Update AWS Java SDK v2 to 2.16.104
+* Update Maven plugins to the latest version
+* Add Enforces and versions maven plugins
 
 ##### Version 1.8.8
 * Fix CloudWatch appenders duplicate logs: https://github.com/sndyuk/logback-more-appenders/pull/71
@@ -106,7 +116,7 @@ Configure your pom.xml:
       <dependency>
         <groupId>com.sndyuk</groupId>
         <artifactId>logback-more-appenders</artifactId>
-        <version>1.8.7</version>
+        <version>1.8.9</version>
       </dependency>
 
       <!-- [Optional] If you use The CloudWatch V2 appender, You need to add the dependency(cloudwatchlogs). -->

--- a/pom-JAVA9MODULE_SLF4J17.xml
+++ b/pom-JAVA9MODULE_SLF4J17.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
@@ -87,7 +87,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -122,7 +122,7 @@
         <plugin>
          <groupId>org.codehaus.mojo</groupId>
            <artifactId>versions-maven-plugin</artifactId>
-           <version>2.19.1</version>
+           <version>2.20.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom-JAVA9MODULE_SLF4J17.xml
+++ b/pom-JAVA9MODULE_SLF4J17.xml
@@ -17,12 +17,12 @@
 
   <properties>
     <fluentd.logger.version>0.3.4</fluentd.logger.version>
-    <fluency.version>2.5.1</fluency.version>
-    <logback.version>1.2.3</logback.version>
+    <fluency.version>2.7.3</fluency.version>
+    <logback.version>1.2.13</logback.version>
     <slf4j.version>1.7.26</slf4j.version>
-    <jackson.version>2.12.3</jackson.version>
-    <aws.version>1.11.1000</aws.version>
-    <aws-v2.version>2.16.43</aws-v2.version>
+    <jackson.version>2.15.2</jackson.version>
+    <aws.version>1.11.1034</aws.version>
+    <aws-v2.version>2.16.104</aws-v2.version>
     <jdk.version>9</jdk.version>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
   </properties>
@@ -34,7 +34,7 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>4.0</version>
+        <version>5.0.0</version>
         <configuration>
           <aggregate>true</aggregate>
           <strictCheck>true</strictCheck>
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.1</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
@@ -56,7 +56,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>add-source</id>
@@ -75,7 +75,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.14.1</version>
         <configuration>
           <fork>true</fork>
           <release>9</release>
@@ -87,7 +87,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -100,7 +100,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.12.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -110,15 +110,43 @@
           </execution>
         </executions>
         <configuration>
-          <source>8</source>
-          <additionalParam>-Xdoclint:none</additionalParam>
+          <source>${jdk.version}</source>
+          <doclint>none</doclint>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.9.0</version>
       </plugin>
+        <plugin>
+         <groupId>org.codehaus.mojo</groupId>
+           <artifactId>versions-maven-plugin</artifactId>
+           <version>2.19.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.6.2</version>
+            <executions>
+                <execution>
+                    <id>enforce-maven</id>
+                    <goals>
+                        <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                        <rules>
+                            <requireMavenVersion>
+                                <version>3.6.3</version>
+                            </requireMavenVersion>
+                            <requireJavaVersion>
+                                <version>${jdk.version}</version>
+                            </requireJavaVersion>
+                        </rules>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 
@@ -211,7 +239,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -263,7 +291,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.8</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -277,7 +305,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>1.7.0</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>

--- a/pom-JAVA9MODULE_SLF4J17.xml
+++ b/pom-JAVA9MODULE_SLF4J17.xml
@@ -17,10 +17,10 @@
 
   <properties>
     <fluentd.logger.version>0.3.4</fluentd.logger.version>
-    <fluency.version>2.7.3</fluency.version>
+    <fluency.version>2.6.5</fluency.version>
     <logback.version>1.2.13</logback.version>
-    <slf4j.version>1.7.26</slf4j.version>
-    <jackson.version>2.15.2</jackson.version>
+    <slf4j.version>1.7.36</slf4j.version>
+    <jackson.version>2.10.5</jackson.version>
     <aws.version>1.11.1034</aws.version>
     <aws-v2.version>2.16.104</aws-v2.version>
     <jdk.version>9</jdk.version>
@@ -112,6 +112,10 @@
         <configuration>
           <source>${jdk.version}</source>
           <doclint>none</doclint>
+          <additionalOptions>
+            <additionalOption>--no-module-directories</additionalOption>
+          </additionalOptions>
+          <detectJavaApiLink>false</detectJavaApiLink>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.1</version>
+        <version>3.15.0</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
           <source>${jdk.version}</source>
@@ -95,12 +95,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.9.0</version>
+        <version>3.10.0</version>
       </plugin>
         <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>versions-maven-plugin</artifactId>
-            <version>2.20.1</version>
+            <version>2.21.0</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -100,7 +100,7 @@
         <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>versions-maven-plugin</artifactId>
-            <version>2.19.1</version>
+            <version>2.20.1</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,11 @@
 
   <properties>
     <fluentd.logger.version>0.3.4</fluentd.logger.version>
-    <fluency.version>2.5.1</fluency.version>
-    <logback.version>1.2.3</logback.version>
-    <jackson.version>2.12.3</jackson.version>
-    <aws.version>1.11.1000</aws.version>
-    <aws-v2.version>2.16.43</aws-v2.version>
+    <fluency.version>2.7.3</fluency.version>
+    <logback.version>1.2.13</logback.version>
+    <jackson.version>2.15.2</jackson.version>
+    <aws.version>1.11.1034</aws.version>
+    <aws-v2.version>2.16.104</aws-v2.version>
     <jdk.version>8</jdk.version>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
   </properties>
@@ -33,7 +33,7 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>4.0</version>
+        <version>5.0.0</version>
         <configuration>
           <aggregate>true</aggregate>
           <strictCheck>true</strictCheck>
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.1</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.14.1</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
           <source>${jdk.version}</source>
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -78,7 +78,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.12.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -89,14 +89,42 @@
         </executions>
         <configuration>
           <source>${jdk.version}</source>
-          <additionalParam>-Xdoclint:none</additionalParam>
+            <doclint>none</doclint>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.9.0</version>
       </plugin>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>versions-maven-plugin</artifactId>
+            <version>2.19.1</version>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.6.2</version>
+            <executions>
+                <execution>
+                    <id>enforce-maven</id>
+                    <goals>
+                        <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                        <rules>
+                            <requireMavenVersion>
+                                <version>3.6.3</version>
+                            </requireMavenVersion>
+                            <requireJavaVersion>
+                                <version>${jdk.version}</version>
+                            </requireJavaVersion>
+                        </rules>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 
@@ -226,7 +254,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.8</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -240,7 +268,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>1.7.0</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 
   <properties>
     <fluentd.logger.version>0.3.4</fluentd.logger.version>
-    <fluency.version>2.7.3</fluency.version>
+    <fluency.version>2.6.5</fluency.version>
     <logback.version>1.2.13</logback.version>
-    <jackson.version>2.15.2</jackson.version>
+    <jackson.version>2.10.5</jackson.version>
     <aws.version>1.11.1034</aws.version>
     <aws-v2.version>2.16.104</aws-v2.version>
     <jdk.version>8</jdk.version>

--- a/src/java9/java/module-info.java
+++ b/src/java9/java/module-info.java
@@ -1,5 +1,5 @@
-open module org.slf4j {
-  requires transitive slf4j.api;
+open module com.sndyuk.logback.more.appenders {
+  requires org.slf4j;
   requires static logback.core;
   requires static logback.classic;
   requires static logback.access;

--- a/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
+++ b/src/main/java/ch/qos/logback/more/appenders/DataFluentAppender.java
@@ -17,6 +17,11 @@ import java.util.Map;
 
 import org.fluentd.logger.FluentLogger;
 
+/**
+ * @deprecated Use {@link FluencyLogbackAppender} instead.
+ * @since 1.8.9
+ */
+@Deprecated
 public class DataFluentAppender<E> extends FluentdAppenderBase<E> {
     private FluentLogger fluentLogger;
 

--- a/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
+++ b/src/main/java/ch/qos/logback/more/appenders/FluentdAppenderBase.java
@@ -32,8 +32,6 @@ import ch.qos.logback.core.encoder.Encoder;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import ch.qos.logback.more.appenders.marker.MapMarker;
 
-
-
 public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
     private static final String DATA_MESSAGE = "message";
     private static final String DATA_LOGGER = "logger";
@@ -82,9 +80,7 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
             if (loggingEvent.getThrowableProxy() != null) {
                 data.put(DATA_THROWABLE, ThrowableProxyUtil.asString(loggingEvent.getThrowableProxy()));
             }
-            for (Map.Entry<String, String> entry : loggingEvent.getMDCPropertyMap().entrySet()) {
-                data.put(entry.getKey(), entry.getValue());
-            }
+            data.putAll(loggingEvent.getMDCPropertyMap());
         } else {
             data.put(messageFieldKeyName, encoder != null ? encoder.encode(event) : event.toString());
         }
@@ -128,9 +124,6 @@ public abstract class FluentdAppenderBase<E> extends AppenderBase<E> {
 
     /**
      * Get map marker name if map is provided
-     * 
-     * @param mapMarker
-     * @return
      */
     protected String mapMarkerName(MapMarker mapMarker) {
         if ((mapMarker == null) || (emptyString(mapMarker.getName()))) {

--- a/src/main/java/ch/qos/logback/more/appenders/encoder/FastJsonEncoder.java
+++ b/src/main/java/ch/qos/logback/more/appenders/encoder/FastJsonEncoder.java
@@ -1,6 +1,5 @@
 package ch.qos.logback.more.appenders.encoder;
 
-import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
 import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.Converter;
@@ -8,7 +7,7 @@ import ch.qos.logback.core.pattern.DynamicConverter;
 import ch.qos.logback.core.pattern.LiteralConverter;
 
 /**
- * JSON encoder. It just escape meta characters of JSON not to lose performance. It doesn't handle
+ * JSON encoder. It just escapes meta characters of JSON not to lose performance. It doesn't handle
  * null value.
  *
  * @author sndyuk

--- a/src/main/java/ch/qos/logback/more/appenders/encoder/ReplacePatternLayoutEncoderBase.java
+++ b/src/main/java/ch/qos/logback/more/appenders/encoder/ReplacePatternLayoutEncoderBase.java
@@ -4,7 +4,6 @@ import java.lang.reflect.Field;
 import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.Converter;
-import ch.qos.logback.core.pattern.FormattingConverter;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.pattern.PatternLayoutEncoderBase;
 

--- a/src/test/java/ch/qos/logback/more/appenders/FluentdAppenderBaseTest.java
+++ b/src/test/java/ch/qos/logback/more/appenders/FluentdAppenderBaseTest.java
@@ -38,7 +38,7 @@ public class FluentdAppenderBaseTest {
     /**
      * Creating a test appender to be a test proxy
      */
-    class TestAppender<E> extends FluentdAppenderBase<E> {
+    static class TestAppender<E> extends FluentdAppenderBase<E> {
         protected List<E> appended = new ArrayList<E>();
 
         @Override
@@ -48,7 +48,7 @@ public class FluentdAppenderBaseTest {
 
     }
 
-    class TestEvent implements ILoggingEvent {
+    static class TestEvent implements ILoggingEvent {
 
         Object[] argumentArray = { "arg1", "arg2" };
         StackTraceElement[] callerData;

--- a/src/test/resources/logback-appenders-fluentd.xml
+++ b/src/test/resources/logback-appenders-fluentd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <included>
 
-  <!-- Fluend java -->
+  <!-- Fluend java (DEPRECATED) use Fluency instead -->
 
   <appender name="FLUENT_SYNC"
     class="ch.qos.logback.more.appenders.DataFluentAppender">


### PR DESCRIPTION
Fixes #78
- Update fluency to 2.6.5
- Update logback to 1.2.13
- Update AWS Java SDK v1 to 1.11.1034
- Update AWS Java SDK v2 to 2.16.104
- Update Maven plugins to the latest version
- Add enforcer and versions maven plugins